### PR TITLE
MIN-40: Addressing erroneous error log

### DIFF
--- a/rest_golang/socket/listener.go
+++ b/rest_golang/socket/listener.go
@@ -35,8 +35,9 @@ func messageHandler(mongoClient *mongo.Client, message []byte) {
 			return
 		}
 		db.InsertUser(mongoClient, user)
+		return
 	} else {
-		log.Println(log.Ldate, " Unrecognized message:", msg)
+		log.Println(log.Ldate, " Unrecognized message - User Insertion:", msg)
 	}
 
 	if val, ok := msgMap["type"]; ok && val == model.WondervilleAsset {
@@ -47,7 +48,7 @@ func messageHandler(mongoClient *mongo.Client, message []byte) {
 		}
 		db.InsertActivityStats(mongoClient, user)
 	} else {
-		log.Println(log.Ldate, " Unrecognized message:", msg)
+		log.Println(log.Ldate, " Unrecognized message - ActivityStats Insertion:", msg)
 	}
 }
 


### PR DESCRIPTION
# Issue
After investigation I believe that the issue was with the previous setup of `messageHandler` inside `listener.go`
The way the checks were being done to determine if a message was an ActivityStat or a User message was not returning, after the user insertion. We also did not have a clear error message pointing to which check was returning the error. The error occurred because the message was determined to be a **user message**, and then inserted into the DB, but was then passed down to the second `if` that checks to see if a message is an activity stat and since it was not it returned an error.
## What was done
* Clarified the error message
* Added return statement after insertion of user into the DB
